### PR TITLE
Added `NewSliceFromPage` factory

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -36,11 +36,11 @@ func ExampleNewSliceFromURL_rowspansAndColspans() {
 		AMDStoreMI        bool   `header:"Storage features AMD StoreMI"`
 		Overclocking      string `header:"Processoroverclocking"`
 		TDP               string `header:"TDP"`
-		SupportExcavator  string `header:"CPU support[14] Excavator"`
-		SupportZen        string `header:"CPU support[14] Zen"`
-		SupportZenPlus    string `header:"CPU support[14] Zen+"`
-		SupportZen2       string `header:"CPU support[14] Zen 2"`
-		SupportZen3       string `header:"CPU support[14] Zen 3"`
+		SupportExcavator  string `header:"CPU support Excavator"`
+		SupportZen        string `header:"CPU support Zen"`
+		SupportZenPlus    string `header:"CPU support Zen+"`
+		SupportZen2       string `header:"CPU support Zen 2"`
+		SupportZen3       string `header:"CPU support Zen 3"`
 		Architecture      string `header:"Architecture"`
 	}
 	am4Chipsets, _ := htmltable.NewSliceFromURL[AM4]("https://en.wikipedia.org/wiki/List_of_AMD_chipsets")
@@ -97,5 +97,5 @@ func ExampleLogger() {
 
 	// Output:
 	// [INFO] found table [columns [Symbol Security SEC filings GICSSector GICS Sub-Industry Headquarters Location Date first added CIK Founded] count 503]
-	// [INFO] found table [columns [Date Added Ticker Added Security Removed Ticker Removed Security Reason] count 312]
+	// [INFO] found table [columns [Date Added Ticker Added Security Removed Ticker Removed Security Reason] count 316]
 }

--- a/slice.go
+++ b/slice.go
@@ -18,6 +18,13 @@ func NewSlice[T any](ctx context.Context, r io.Reader) ([]T, error) {
 	return f.slice()
 }
 
+// NewSliceFromPage finds a table matching the slice and returns the slice
+func NewSliceFromPage[T any](p *Page) ([]T, error) {
+	return (&feeder[T]{
+		Page: *p,
+	}).slice()
+}
+
 // NewSliceFromString is same as NewSlice(context.Context, io.Reader),
 // but takes just a string.
 func NewSliceFromString[T any](in string) ([]T, error) {

--- a/slice_test.go
+++ b/slice_test.go
@@ -33,6 +33,15 @@ func TestNewSliceFromUrl(t *testing.T) {
 	assertGreaterOrEqual(t, len(out), 500)
 }
 
+func TestNewSliceFromPage(t *testing.T) {
+	url := "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+	p, err := NewFromURL(url)
+	assertNoError(t, err)
+	out, err := NewSliceFromPage[Ticker](p)
+	assertNoError(t, err)
+	assertGreaterOrEqual(t, len(out), 500)
+}
+
 func TestNewSliceFromUrl_Fails(t *testing.T) {
 	_, err := NewSliceFromURL[Ticker]("https://127.0.0.1")
 	assertEqualError(t, err, "Get \"https://127.0.0.1\": dial tcp 127.0.0.1:443: connect: connection refused")


### PR DESCRIPTION
This PR adds convenience function to get a slice of annotated entities from `htmltable.Page` instance.

Closes #6